### PR TITLE
Changed to UNIT scope

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -5,7 +5,7 @@ from charms.reactive import scopes
 
 
 class ProvidesRedis(RelationBase):
-    scope = scopes.GLOBAL
+    scope = scopes.UNIT
 
     @hook('{provides:redis}-relation-{joined,changed}')
     def changed(self):
@@ -28,8 +28,6 @@ class ProvidesRedis(RelationBase):
             uri = 'redis://:{password}@{host}:{port}'.format(**relation_info)
         else:
             uri = 'redis://{host}:{port}'.format(**relation_info)
-
         relation_info['uri'] = uri
-
-        conv = self.conversation()
-        conv.set_remote(**relation_info)
+        for conv in self.conversations():
+            conv.set_remote(**relation_info)

--- a/requires.py
+++ b/requires.py
@@ -9,10 +9,10 @@ class RedisRequires(RelationBase):
 
     @hook('{requires:redis}-relation-{joined,changed}')
     def changed(self):
-        self.set_state('{relation_name}.connected')
         conv = self.conversation()
+        conv.set_state('{relation_name}.connected')
         if conv.get_remote('port'):
-            self.set_state('{relation_name}.available')
+            conv.set_state('{relation_name}.available')
 
     @hook('{requires:redis}-relation-{broken,departed}')
     def broken(self):


### PR DESCRIPTION
I was having some problems when using the layer-redis with this interface. I have 2 applications that need the redis charm. My second relationship never was able to get the port so the `redis.available` was never set. By changing the scope to Unit and using conversations this was fixed. I also updated the `layer-redis` (https://github.com/jamesbeedy/layer-redis) to work with this new interface. I will create the pull request later today